### PR TITLE
fix: make apple certificates optional for non-ios builds

### DIFF
--- a/lib/src/commands/infra_build_command.dart
+++ b/lib/src/commands/infra_build_command.dart
@@ -154,14 +154,16 @@ class InfraBuildCommand extends BaseCommand {
       envHandler = _getEnvironmentVariableHandler(envHandlerType, commandArgs);
     }
 
-    final CertificatesManager certificatesManager =
-        buildConfiguration.getCertificatesManager();
+    CertificatesManager? certificatesManager;
+    ProvisionProfileManager? profilesManager;
+    BundleIdManager? bundleIdManager;
 
-    final ProvisionProfileManager profilesManager =
-        buildConfiguration.getProfilesManager(certificatesManager, infraDir);
-
-    final BundleIdManager bundleIdManager =
-        buildConfiguration.getBundleManager();
+    if (buildTargetPlatforms.contains(BuildTargetPlatform.ios)) {
+      certificatesManager = buildConfiguration.getCertificatesManager();
+      profilesManager =
+          buildConfiguration.getProfilesManager(certificatesManager, infraDir);
+      bundleIdManager = buildConfiguration.getBundleManager();
+    }
 
     BDLogger().info(
       'Building ${buildConfiguration.iosAppId} with '
@@ -179,11 +181,11 @@ class InfraBuildCommand extends BaseCommand {
         final File iosFlutterOutput = await FlutterIosBuildExecutor(
           buildFlavor: buildFlavor,
           projectDirectory: projectDir,
-          bundleIdManager: bundleIdManager,
+          bundleIdManager: bundleIdManager!,
           configuration: buildConfiguration,
           environmentVariableHandler: envHandler,
-          certificatesManager: certificatesManager,
-          provisionProfilesManager: profilesManager,
+          certificatesManager: certificatesManager!,
+          provisionProfilesManager: profilesManager!,
           runner: ShellRunner(workingDirectory: projectDir),
         ).build();
 
@@ -206,7 +208,7 @@ class InfraBuildCommand extends BaseCommand {
           'iOS application created successfully: ${iosFlutterOutput.path}',
         );
       } on Object catch (_) {
-        certificatesManager.cleanupLocally();
+        certificatesManager?.cleanupLocally();
         rethrow;
       }
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: db_infra
 description: A command-line tool that help to automate your release workflow.
-version: 0.5.2
+version: 0.5.3
 homepage: https://github.com/db_infra
 
 


### PR DESCRIPTION
This pull request updates the iOS build logic in `InfraBuildCommand` to better handle platform-specific build resources and to prevent unnecessary initialization of iOS-specific managers when not building for iOS. It also bumps the package version to 0.5.3.

**iOS Build Resource Initialization Improvements:**

* Only initializes `CertificatesManager`, `ProvisionProfileManager`, and `BundleIdManager` if the build includes iOS as a target, preventing unnecessary resource allocation for non-iOS builds.

* Updates the usage of these managers in the iOS build executor to use non-null assertions, ensuring they are only accessed when properly initialized for iOS builds.

* Changes the cleanup logic for the certificates manager to use a null-aware call, preventing errors if the manager was never initialized (i.e., in non-iOS builds).

**Version Update:**

* Bumps the package version from 0.5.2 to 0.5.3 in `pubspec.yaml`.